### PR TITLE
Added Search feature to Youtube Scraper

### DIFF
--- a/skrapers/src/main/kotlin/ru/sokomishalov/skraper/provider/youtube/YoutubeSkraperExtensions.kt
+++ b/skrapers/src/main/kotlin/ru/sokomishalov/skraper/provider/youtube/YoutubeSkraperExtensions.kt
@@ -31,3 +31,7 @@ fun YoutubeSkraper.getUserPosts(username: String): Flow<Post> {
 suspend fun YoutubeSkraper.getUserInfo(username: String): PageInfo? {
     return getPageInfo(path = "/user/${username}")
 }
+
+fun YoutubeSkraper.getSearchPosts(keyword: String): Flow<Post> {
+    return getPosts(path = "/results?search_query=${keyword.replace(" ","+")}")
+}

--- a/skrapers/src/test/kotlin/ru/sokomishalov/skraper/provider/youtube/YoutubeSkraperTest.kt
+++ b/skrapers/src/test/kotlin/ru/sokomishalov/skraper/provider/youtube/YoutubeSkraperTest.kt
@@ -45,4 +45,9 @@ class YoutubeSkraperTest : SkraperTck() {
     fun `Check media downloading`() {
         assertMediaDownloaded(Video("https://youtu.be/fjUO7xaUHJQ"))
     }
+
+    @Test
+    fun `Check search results`() {
+        assertPosts { skraper.getSearchResults("Nothing Else Matters") }
+    }
 }

--- a/skrapers/src/test/kotlin/ru/sokomishalov/skraper/provider/youtube/YoutubeSkraperTest.kt
+++ b/skrapers/src/test/kotlin/ru/sokomishalov/skraper/provider/youtube/YoutubeSkraperTest.kt
@@ -47,7 +47,7 @@ class YoutubeSkraperTest : SkraperTck() {
     }
 
     @Test
-    fun `Check search results`() {
-        assertPosts { skraper.getSearchResults("Nothing Else Matters") }
+    fun `Check search posts`() {
+        assertPosts { skraper.getSearchPosts("Nothing Else Matters") }
     }
 }


### PR DESCRIPTION
Added Search feature with keyword with a corresponding test using `assertPosts`.
Also fixed an issue where video's views would be in this format `150,100,100` format (with commas).
One problem we need to address that the `views `property in `PostStatistics` is `Int?` where there are videos that exceeds that limit, didn't want to change it as it's tightly coupled with the rest of the scrapers.